### PR TITLE
ci: GHA - remove context

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Build container image
         uses: docker/build-push-action@v2
         with:
-          context: .
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
Forgot to nix this during testing. We don't need to supply context to the
push action.